### PR TITLE
Access form value through HttpContextBase

### DIFF
--- a/RecaptchaV3/Forms/Recaptcha3.cs
+++ b/RecaptchaV3/Forms/Recaptcha3.cs
@@ -31,7 +31,7 @@ namespace Recaptcha.Forms
         public override IEnumerable<string> ValidateField(Form form, Field field, IEnumerable<object> postedValues, HttpContextBase context, IFormStorage formStorage)
         {
             var returnStrings = new List<string>();
-            var token = HttpContext.Current.Request["g-recaptcha-response"];
+            var token = context.Request.Form["g-recaptcha-response"];
             string secret = Configuration.GetSetting("RecaptchaPrivateKey");
             var client = new WebClient();
             var jsonResult = client.DownloadString(string.Format("https://www.google.com/recaptcha/api/siteverify?secret={0}&response={1}", secret, token));


### PR DESCRIPTION
Currently the `g-recaptcha-response` form field value is accessed through `HttpContext.Current.Request` but you can access it through `HttpContextBase` parameter instead.

The field should btw. be a hidden input as fixed in https://github.com/shaishavkarnani/RecaptchaV3/pull/3