### PR TITLE
Set recaptcha token using vanilla JS

### DIFF
--- a/RecaptchaV3/Views/Partials/Forms/Fieldtypes/Fieldtype.Recaptcha3.cshtml
+++ b/RecaptchaV3/Views/Partials/Forms/Fieldtypes/Fieldtype.Recaptcha3.cshtml
@@ -2,22 +2,21 @@
 @model Umbraco.Forms.Mvc.Models.FieldViewModel
 @{
     var siteKey = Umbraco.Forms.Core.Configuration.GetSetting("RecaptchaPublicKey");
-    var Usecase = "homepage";
+    var usecase = "homepage";
     var themeSetting = Model.AdditionalSettings.FirstOrDefault(x => x.Key == "AdditionalSettings");
     if (themeSetting.Value != "")
     {
-        Usecase = themeSetting.Value;
+        usecase = themeSetting.Value;
     }
 
     if (!string.IsNullOrEmpty(siteKey))
     {
-
         <script src="https://www.google.com/recaptcha/api.js?render=@siteKey"></script>
         <input type="text" id="@Model.Id" name="g-recaptcha-response" />
         <script>
             grecaptcha.ready(function() {
-                grecaptcha.execute('@siteKey', { action: '@Usecase' }).then(function (token) {
-                    $("#@(Model.Id)").val(token);
+                grecaptcha.execute('@siteKey', { action: '@usecase' }).then(function (token) {
+                    document.getElementById(@(Model.Id)).value = token;
                     console.log(token);
                 });
             });

--- a/RecaptchaV3/Views/Partials/Forms/Fieldtypes/Fieldtype.Recaptcha3.cshtml
+++ b/RecaptchaV3/Views/Partials/Forms/Fieldtypes/Fieldtype.Recaptcha3.cshtml
@@ -16,7 +16,7 @@
         <script>
             grecaptcha.ready(function() {
                 grecaptcha.execute('@siteKey', { action: '@usecase' }).then(function (token) {
-                    document.getElementById(@(Model.Id)).value = token;
+                    document.getElementById("@Model.Id").value = token;
                     console.log(token);
                 });
             });

--- a/RecaptchaV3/Views/Partials/Forms/Themes/default/Fieldtypes/Fieldtype.Recaptcha3.cshtml
+++ b/RecaptchaV3/Views/Partials/Forms/Themes/default/Fieldtypes/Fieldtype.Recaptcha3.cshtml
@@ -2,11 +2,11 @@
 @model Umbraco.Forms.Mvc.Models.FieldViewModel
 @{
     var siteKey = Umbraco.Forms.Core.Configuration.GetSetting("RecaptchaPublicKey");
-    var Usecase = "homepage";
+    var usecase = "homepage";
     var themeSetting = Model.AdditionalSettings.FirstOrDefault(x => x.Key == "AdditionalSettings");
     if (themeSetting.Value != "")
     {
-        Usecase = themeSetting.Value;
+        usecase = themeSetting.Value;
     }
 
     if (!string.IsNullOrEmpty(siteKey))
@@ -16,8 +16,8 @@
         <input type="text" id="@Model.Id" name="g-recaptcha-response" />
         <script>
             grecaptcha.ready(function() {
-                grecaptcha.execute('@siteKey', { action: '@Usecase' }).then(function (token) {
-                    $("#@(Model.Id)").val(token);
+                grecaptcha.execute('@siteKey', { action: '@usecase' }).then(function (token) {
+                    document.getElementById(@(Model.Id)).value = token;
                     console.log(token);
                 });
             });

--- a/RecaptchaV3/Views/Partials/Forms/Themes/default/Fieldtypes/Fieldtype.Recaptcha3.cshtml
+++ b/RecaptchaV3/Views/Partials/Forms/Themes/default/Fieldtypes/Fieldtype.Recaptcha3.cshtml
@@ -11,7 +11,6 @@
 
     if (!string.IsNullOrEmpty(siteKey))
     {
-
         <script src="https://www.google.com/recaptcha/api.js?render=@siteKey"></script>
         <input type="text" id="@Model.Id" name="g-recaptcha-response" />
         <script>

--- a/RecaptchaV3/Views/Partials/Forms/Themes/default/Fieldtypes/Fieldtype.Recaptcha3.cshtml
+++ b/RecaptchaV3/Views/Partials/Forms/Themes/default/Fieldtypes/Fieldtype.Recaptcha3.cshtml
@@ -16,7 +16,7 @@
         <script>
             grecaptcha.ready(function() {
                 grecaptcha.execute('@siteKey', { action: '@usecase' }).then(function (token) {
-                    document.getElementById(@(Model.Id)).value = token;
+                    document.getElementById("@Model.Id").value = token;
                     console.log(token);
                 });
             });


### PR DESCRIPTION
Umbraco Forms now support rendering forms without jQuery and in this case the token can be set using vanilla JS.